### PR TITLE
Adapt perf data on net checks

### DIFF
--- a/modules/host_net_info.pm
+++ b/modules/host_net_info.pm
@@ -50,16 +50,17 @@ sub host_net_info
        if (defined($values))
           {
           $value = simplify_number(convert_number($$values[0][0]->value));
+          $perfvalue = $value * 1024;
           if ($subselect eq "all")
              {
              $output = "net usage=" . $value . " KBps";
-             $perfdata = "\'net_usage\'=" . $value . ";". $perf_thresholds . ";;";
+             $perfdata = "\'net_usage\'=" . $perfvalue . "B;". $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "net usage=" . $value . " KBps";
-             $perfdata = "\'net_usage\'=" . $value . ";" . $perf_thresholds . ";;";
+             $perfdata = "\'net_usage\'=" . $perfvalue . "B;" . $perf_thresholds . ";;";
              $state = check_state($state, $actual_state);
              }
           }
@@ -77,16 +78,17 @@ sub host_net_info
        if (defined($values))
           {
           $value = simplify_number(convert_number($$values[0][1]->value));
+          $perfvalue = $value * 1024;
           if ($subselect eq "all")
              {
              $output = $output . " net receive=" . $value . " KBps";
-             $perfdata = $perfdata . " \'net_receive\'=" . $value . ";" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'net_receive\'=" . $perfvalue . "B;" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "net receive=" . $value . " KBps";
-             $perfdata = "\'net_receive\'=" . $value . ";" . $perf_thresholds . ";;";
+             $perfdata = "\'net_receive\'=" . $perfvalue . "B;" . $perf_thresholds . ";;";
              $state = check_state($state, $actual_state);
              }
           }
@@ -113,16 +115,17 @@ sub host_net_info
        if (defined($values))
           {
           $value = simplify_number(convert_number($$values[0][2]->value));
+          $perfvalue = $value * 1024;
           if ($subselect eq "all")
              {
              $output =$output . ", net send=" . $value . " KBps"; 
-             $perfdata = $perfdata . " \'net_send\'=" . $value . ";" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'net_send\'=" . $perfvalue . "B;" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "net send=" . $value . " KBps"; 
-             $perfdata = "\'net_send\'=" . $value . ";" . $perf_thresholds . ";;";
+             $perfdata = "\'net_send\'=" . $perfvalue . "B;" . $perf_thresholds . ";;";
              $state = check_against_threshold($value);
              }
           }


### PR DESCRIPTION
This allows that the values in performance data line appear "correctly" with $valueB as outlined in the nagios plugins developer guidelines. 

Example (without thresholds):

```
net_usage=2418688B;;;;
```

So graphing tools like pnp4nagios or nagiosgraph are automatically drawing correct graphs. 
