### PR TITLE
Use Vim::get_views instead of Vim::get_view

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -2480,7 +2480,7 @@ sub catch_alarm
     {
     print "UNKNOWN: Script timed out.\n";
     require Carp;
-    Carp::cluck "We timed out, this is the current backtrace:"
+    Carp::cluck "We timed out, this is the current backtrace:";
     exit 3;
     }
 

--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -2479,6 +2479,8 @@ sub get_me_out
 sub catch_alarm
     {
     print "UNKNOWN: Script timed out.\n";
+    require Carp;
+    Carp::cluck "We timed out, this is the current backtrace:"
     exit 3;
     }
 

--- a/modules/datastore_volumes_info.pm
+++ b/modules/datastore_volumes_info.pm
@@ -55,11 +55,10 @@ sub datastore_volumes_info
        {
        $isregexp = 0;
        }
-               
-    foreach $ref_store (@{$datastore})
-            {
-            $store = Vim::get_view(mo_ref => $ref_store, properties => ['summary', 'info']);
 
+    my $stores = Vim::get_views(mo_ref_array => $datastore, properties => ['summary', 'info']);
+    foreach my $store (@{$stores})
+            {
             $name = $store->summary->name;
             $volume_type = $store->summary->type;
 


### PR DESCRIPTION
Hi,

with a large number of datastores resolving them one by one may get slow. I've found `Vim::get_views` to do that in one request.

Also printing a stacktrace on timeout happened to be very useful to get an idea of what is going on.

Danijel
