### PR TITLE
Fix Can't Kill Non-Numeric Process

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -1741,7 +1741,14 @@ if (!defined($nosession))
          close (SESSION_LOCK_FILE);    
       
          # Third - check for the process which wrote the lock file the last time
-         $PID_exists = kill 0, $PID_old;
+         if ( $PID_old )
+            {
+                $PID_exists = kill (0, $PID_old);
+            }
+         else
+             {
+                 $PID_exists = undef;
+             }
          
          # Fourth - if the process is not available any more remove the lock file
          if ( !$PID_exists )


### PR DESCRIPTION
The code returned an error whenever the old PID was undefined since kill
can't kill an undefined PID. Changed it so it would check if the PID
exists first and then tries to kill. Maybe if the server restarts there isn't an old PID or something.