### PR TITLE
Removed not supported UOMs from perfdata output.

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -1228,6 +1228,15 @@
 #    - Bugfix: --nosession was printed out twice. Same line the not "not" was missing.
 #      This was bad because it changed the meaning of the line. Same error in the command reference
 #      because the reference is only the output from the help in a file.
+#- 24 Feb 2017 C.Koebke
+#   - check_vmware_esx.pl:
+#     - Changed SSL certificate validation code for newer LWP versions
+#   - vm_disk_io_info()
+#     - Removed not supported UOMs from perfdata output.
+#   - host_disk_io_info()
+#     - Removed not supported UOMs from perfdata output.
+
+
 
 use strict;
 use warnings;
@@ -1247,7 +1256,15 @@ use datastore_volumes_info;
 
 # Prevent SSL certificate validation
 
-$ENV{'PERL_LWP_SSL_VERIFY_HOSTNAME'} = 0; 
+BEGIN {
+    $ENV{'PERL_LWP_SSL_VERIFY_HOSTNAME'} = 0;
+    eval {
+        # required for new IO::Socket::SSL versions
+        require IO::Socket::SSL;
+        IO::Socket::SSL->import();
+        IO::Socket::SSL::set_ctx_defaults( SSL_verify_mode => 0 );
+    };
+};
 
 if ( $@ )
    {

--- a/modules/datastore_volumes_info.pm
+++ b/modules/datastore_volumes_info.pm
@@ -55,11 +55,10 @@ sub datastore_volumes_info
        {
        $isregexp = 0;
        }
-               
-    foreach $ref_store (@{$datastore})
-            {
-            $store = Vim::get_view(mo_ref => $ref_store, properties => ['summary', 'info']);
 
+    my $stores = Vim::get_views(mo_ref_array => $datastore, properties => ['summary', 'info']);
+    foreach my $store (@{$stores})
+            {
             $name = $store->summary->name;
             $volume_type = $store->summary->type;
 

--- a/modules/host_disk_io_info.pm
+++ b/modules/host_disk_io_info.pm
@@ -99,13 +99,13 @@ sub host_disk_io_info
           if ($subselect eq "all")
              {
              $output = $output . " - I/O read=" . $value . " KB/sec.";
-             $perfdata = $perfdata . " \'io_read\'=" . $value . "KB;" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'io_read\'=" . $value . ";" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "I/O read=" . $value . " KB/sec.";
-             $perfdata = "\'io_read\'=" . $value . "KB;" . $perf_thresholds . ";;";
+             $perfdata = "\'io_read\'=" . $value . ";" . $perf_thresholds . ";;";
              $state = check_against_threshold($value);
              }
           }
@@ -171,13 +171,13 @@ sub host_disk_io_info
           if ($subselect eq "all")
              {
              $output = $output . " - I/O write=" . $value . " KB/sec.";
-             $perfdata = $perfdata . " \'io_write\'=" . $value . "KB;" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'io_write\'=" . $value . ";" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "I/O write=" . $value . " KB/sec.";
-             $perfdata = "\'io_write\'=" . $value . "KB;" . $perf_thresholds . ";;";
+             $perfdata = "\'io_write\'=" . $value . ";" . $perf_thresholds . ";;";
              $state = check_against_threshold($value);
              }
           }
@@ -243,13 +243,13 @@ sub host_disk_io_info
           if ($subselect eq "all")
              {
              $output = $output . " - I/O usage=" . $value . " KB/sec.";
-             $perfdata = $perfdata . " \'io_usage\'=" . $value . "KB;;;";
+             $perfdata = $perfdata . " \'io_usage\'=" . $value . ";;;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "I/O usage=" . $value . " KB/sec., ";
-             $perfdata = "\'io_usage\'=" . $value . "KB;;;";
+             $perfdata = "\'io_usage\'=" . $value . ";;;";
              $state = check_against_threshold($value);
              }
           }

--- a/modules/vm_disk_io_info.pm
+++ b/modules/vm_disk_io_info.pm
@@ -36,13 +36,13 @@ sub vm_disk_io_info
           if ($subselect eq "all")
              {
              $output = "I/O usage=" . $value . " KB/s";
-             $perfdata = $perfdata . " \'io_usage\'=" . $value . "KB/s;" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'io_usage\'=" . $value . ";" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "I/O usage=" . $value . " KB/s";
-             $perfdata = "\'io_usage\'=" . $value . "KB/s;" . $perf_thresholds . ";;";
+             $perfdata = "\'io_usage\'=" . $value . ";" . $perf_thresholds . ";;";
              $state = check_state($state, $actual_state);
              }
           }
@@ -63,13 +63,13 @@ sub vm_disk_io_info
           if ($subselect eq "all")
              {
              $output = $output . " - I/O read=" . $value . " KB/s";
-             $perfdata = $perfdata . " \'io_read\'=" . $value . "KB/s;" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'io_read\'=" . $value . ";" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "I/O read=" . $value . " KB/s";
-             $perfdata = " \'io_read\'=" . $value . "KB/s;" . $perf_thresholds . ";;";
+             $perfdata = " \'io_read\'=" . $value . ";" . $perf_thresholds . ";;";
              $state = check_state($state, $actual_state);
              }
           }
@@ -99,13 +99,13 @@ sub vm_disk_io_info
           if ($subselect eq "all")
              {
              $output = $output . " - I/O write=" . $value . " KB/s";
-             $perfdata = $perfdata . " \'io_write\'=" . $value . "KB/s;" . $perf_thresholds . ";;";
+             $perfdata = $perfdata . " \'io_write\'=" . $value . ";" . $perf_thresholds . ";;";
              }
           else
              {
              $actual_state = check_against_threshold($value);
              $output = "I/O write=" . $value . " KB/s";
-             $perfdata = " \'io_write\'=" . $value . "KB/s;" . $perf_thresholds . ";;";
+             $perfdata = " \'io_write\'=" . $value . ";" . $perf_thresholds . ";;";
              $state = check_state($state, $actual_state);
              }
           }


### PR DESCRIPTION
I removed the not supported UOMs , as Icinga2 ignores perfdata with not supported UOMs.
Also changed the code for SSL validation, as the original didnt work anymore with newer LWP version/VMware SDKs. Now its working perfect with SDK 6.5