### PR TITLE
warn if no volumes match

### DIFF
--- a/modules/datastore_volumes_info.pm
+++ b/modules/datastore_volumes_info.pm
@@ -290,7 +290,7 @@ sub datastore_volumes_info
        $output = $tmp_output;
        }
 
-    if ($output)
+    if ($tmp_output or $tmp_output_error)
        {
        if ( $state == 0 )
           {
@@ -324,7 +324,12 @@ sub datastore_volumes_info
        }
     else
        {
-       if ($alertonly)
+       if(!$tmp_output and !$tmp_output_error)
+           {
+           $output = "No matching volumes found";
+           $state = 1;
+           }
+       elsif($alertonly)
           {
           $output = "OK. There are no alerts";
           }


### PR DESCRIPTION
With `-S volumes -s volname` the check did return OK if there was no volume with that name. Now it emits a warning. Also if no volumes matching a regex check are found a warning is emitted.