### PR TITLE
Add feature to request VM snapshots (enhanced/fixed lausser version)

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -2114,6 +2114,13 @@ sub main_select
           ($result, $output) = soap_check();
           return($result, $output);
           }
+       if ($select eq "snapshots")
+          {
+          require host_snapshot_info;
+          import host_snapshot_info;
+          ($result, $output) = host_snapshot_info($esx_server);
+          return($result, $output);
+          }
 
           get_me_out("Unknown host select");
         }
@@ -2165,6 +2172,13 @@ sub main_select
        if ($select eq "soap")
           {
           ($result, $output) = soap_check();
+          return($result, $output);
+          }
+       if ($select eq "snapshots")
+          {
+          require dc_snapshot_info;
+          import dc_snapshot_info;
+          ($result, $output) = dc_snapshot_info();
           return($result, $output);
           }
 

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -1,0 +1,208 @@
+sub dc_snapshot_info
+    {
+    my $count = 0;
+    my $state;
+    my $output;
+    my $host_view;
+    my $vm_views;
+    my $vm;
+    my $istemplate;
+    my $match;
+    my $displayname;
+    my $devices;
+   
+    $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', properties => ['name', 'config.template', 'snapshot', 'runtime.powerState']);
+
+    if (!defined($vm_views))
+       {
+       print "Runtime error\n";
+       exit 2;
+       }
+    $output = '';
+
+    if (!defined($subselect))
+       {
+       $subselect = "age";
+       }
+
+    foreach $vm (@$vm_views)
+            {
+            my $vm_snapinfo = $vm->{snapshot};
+            next unless defined $vm_snapinfo;
+            # change get_property to {} to avoid infinite loop
+            $istemplate = $vm->{'config.template'};
+            
+            if ($istemplate && ($istemplate eq 'true'))
+               {
+               next;
+               }
+            
+            $match = 0;
+            $displayname = $vm->name;
+
+            if (defined($isregexp))
+               {
+               $isregexp = 1;
+               }
+            else
+               {
+               $isregexp = 0;
+               }
+               
+            if (defined($blacklist))
+               {
+               if (isblacklisted(\$blacklist, $isregexp, $displayname))
+                  {
+                  next;
+                  }
+               }
+            if (defined($whitelist))
+               {
+               if (isnotwhitelisted(\$whitelist, $isregexp, $displayname))
+                  {
+                  next;
+                  }
+               }
+            my $snapstate = 0;
+            my $snapoutput = "";
+            if ($subselect eq "age")
+               {
+               ($snapstate, $snapoutput) = check_snapshot_age( $vm->{name}, $vm_snapinfo->{rootSnapshotList} );
+               }
+               elsif ($subselect eq "count")
+               {
+               my %vm_snapshot_count;
+               ($snapstate, $snapoutput) = check_snapshot_count( $vm->{name},
+                   $vm_snapinfo->{rootSnapshotList}, \%vm_snapshot_count );
+               }
+            if ($snapstate)
+               {
+               $state = final_state($state, $snapstate);
+               $multiline = "<br>";
+               $count++;
+               $output = "$snapoutput" . $multiline . $output;
+               }
+               else
+               {
+               if ($listall)
+                  {
+                  $output = $output . "$snapoutput" . $multiline;
+                  }
+               }
+            }
+
+    #Cut the last multiline of $output. Second line is better than 2 time chop() like the original :-)
+    if ($output ne '')
+       {
+       $output  =~ s/<br>$//i;
+       $output  =~ s/\n$//i;
+       }
+
+    if ($count)
+       {
+       $output = "VMs with snapshots:" . $multiline . $output;
+       #$state = 1;
+       }
+    else
+       {
+       if ($listall)
+          {
+          $output = "No VMs with outdated/too many snapshots found. VMs." . $multiline . $output;
+          }
+       else
+          {
+          $output = "No VMs with outdated/too many snapshots found.";
+          }
+       $state = 0;
+       }
+
+    return ($state, $output);
+    }
+
+sub check_snapshot_age
+    {
+    my $vm_name = shift;
+    my $vm_snaplist = shift;
+    my $output = "";
+    my $state = 0;
+    $multiline = "<br>";
+    foreach my $vm_snap (@{$vm_snaplist})
+            {
+            if ($vm_snap->{childSnapshotList})
+               {
+               my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
+               if ($cstate)
+                  {
+                  $output = $output . $multiline . $coutput;
+                  $state = final_state($state, $cstate);
+                  }
+               }
+
+            my $epoch_snap = str2time( $vm_snap->{createTime} );
+            my $days_snap = ( ( time() - $epoch_snap ) / 86400 );
+            my $tstate = check_against_threshold($days_snap);
+            if ($tstate)
+               {
+               $output = $output . $multiline . sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
+                $vm_snap->{name}, $vm_name, $days_snap;
+               $state = final_state($state, $tstate);
+               }
+            }
+    return ($state, $output);
+    }
+
+sub check_snapshot_count
+    {
+    my $vm_name = shift;
+    my $vm_snaplist = shift;
+    my $vm_snapcount = shift;
+    my $recursion = shift || 0;
+    my $output = "";
+    my $state = 0;
+    $multiline = "<br>";
+
+    foreach my $vm_snap (@{$vm_snaplist})
+            {
+            if ($vm_snap->{childSnapshotList})
+               {
+               my ($cstate, $coutput) = check_snapshot_count($vm_name, $vm_snap->{childSnapshotList}, $vm_snapcount, 1);
+               }
+               $vm_snapcount->{$vm_name}++;
+            }
+            if ($recursion == 0)
+               {
+               my $tstate = check_against_threshold($vm_snapcount->{$vm_name});
+               $output = $output . $multiline . sprintf "VM '%s' has %d snapshots",
+                   $vm_name, $vm_snapcount->{$vm_name};
+               $state = final_state($state, $tstate);
+               return ($state, $output);
+               }
+    }
+
+sub final_state
+    {
+    my ($state1, $state2) = @_;
+    my $final_state = 0;
+    if ($state1)
+       {
+       if ($state2 == 2)
+          {
+          return $state2;
+          }
+          elsif ($state1 == 1 && $state2 == 3)
+          {
+          return $state1;
+          }
+          else
+          {
+          return $state1;
+          }
+       }
+       else
+       {
+       return $state2;
+       }
+    }
+# A module always must end with a returncode of 1. So placing 1 at the end of a module
+# is a common method to ensure this.
+1;

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -79,13 +79,13 @@ sub dc_snapshot_info
                {
                $state = final_state($state, $snapstate);
                $count++;
-               $output = "$snapoutput" . $multiline . $output;
+               $output .= $snapoutput . $multiline;
                }
                else
                {
                if ($listall)
                   {
-                  $output .= "$snapoutput" . $multiline;
+                  $output .= $snapoutput . $multiline;
                   }
                }
             }
@@ -105,7 +105,7 @@ sub dc_snapshot_info
        {
        if ($listall)
           {
-          $output = "No VMs with outdated/too many snapshots found. VMs." . $multiline . $output;
+          $output = "No VMs with outdated/too many snapshots found. VMs:" . $multiline . $output;
           }
        else
           {
@@ -129,7 +129,7 @@ sub check_snapshot_age
             if ($vm_snap->{childSnapshotList})
                {
                my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
-               if ($cstate)
+               if ($cstate || $listall)
                   {
                   $output .= $coutput . $multiline;
                   $state = final_state($state, $cstate);
@@ -139,7 +139,7 @@ sub check_snapshot_age
             my $epoch_snap = str2time( $vm_snap->{createTime} );
             my $days_snap = ( ( time() - $epoch_snap ) / 86400 );
             my $tstate = check_against_threshold($days_snap);
-            if ($tstate)
+            if ($tstate || $listall)
                {
                $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
                 $vm_snap->{name}, $vm_name, $days_snap . $multiline;

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -3,6 +3,7 @@ sub dc_snapshot_info
     my $count = 0;
     my $state;
     my $output;
+    my $output_subselect_text;
     my $host_view;
     my $vm_views;
     my $vm;
@@ -97,19 +98,26 @@ sub dc_snapshot_info
        $output  =~ s/\n$//i;
        }
 
+    if ($subselect eq "age")
+       {
+       $output_subselect_text = "outdated";
+       } else {
+       $output_subselect_text = "too many";
+       }
+
     if ($count)
        {
-       $output = "VMs with snapshots:" . $multiline . $output;
+       $output = "VMs with " . $output_subselect_text . " snapshots:" . $multiline . $output;
        }
     else
        {
        if ($listall)
           {
-          $output = "No VMs with outdated/too many snapshots found. VMs:" . $multiline . $output;
+          $output = "No VMs with " . $output_subselect_text . " snapshots found. VMs:" . $multiline . $output;
           }
        else
           {
-          $output = "No VMs with outdated/too many snapshots found.";
+          $output = "No VMs with " . $output_subselect_text . " snapshots found.";
           }
        $state = 0;
        }
@@ -142,7 +150,7 @@ sub check_snapshot_age
             if ($tstate || $listall)
                {
                $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
-                $vm_snap->{name}, $vm_name, $days_snap . $multiline;
+                $vm_snap->{name}, $vm_name, $days_snap;
                $state = final_state($state, $tstate);
                }
             }
@@ -169,8 +177,8 @@ sub check_snapshot_count
             if ($recursion == 0)
                {
                my $tstate = check_against_threshold($vm_snapcount->{$vm_name});
-               $output .= sprintf "VM '%s' has %d snapshots",
-                   $vm_name, $vm_snapcount->{$vm_name} . $multiline;
+               $output .= sprintf "VM '%s' has %d snapshot%s",
+                   $vm_name, $vm_snapcount->{$vm_name}, ($vm_snapcount->{$vm_name} gt 1 ) ? "s" : "";
                $state = final_state($state, $tstate);
                return ($state, $output);
                }

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -10,7 +10,7 @@ sub dc_snapshot_info
     my $match;
     my $displayname;
     my $devices;
-   
+
     $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', properties => ['name', 'config.template', 'snapshot', 'runtime.powerState']);
 
     if (!defined($vm_views))
@@ -31,12 +31,12 @@ sub dc_snapshot_info
             next unless defined $vm_snapinfo;
             # change get_property to {} to avoid infinite loop
             $istemplate = $vm->{'config.template'};
-            
+
             if ($istemplate && ($istemplate eq 'true'))
                {
                next;
                }
-            
+
             $match = 0;
             $displayname = $vm->name;
 
@@ -48,7 +48,7 @@ sub dc_snapshot_info
                {
                $isregexp = 0;
                }
-               
+
             if (defined($blacklist))
                {
                if (isblacklisted(\$blacklist, $isregexp, $displayname))
@@ -78,7 +78,6 @@ sub dc_snapshot_info
             if ($snapstate)
                {
                $state = final_state($state, $snapstate);
-               $multiline = "<br>";
                $count++;
                $output = "$snapoutput" . $multiline . $output;
                }
@@ -125,7 +124,7 @@ sub check_snapshot_age
     my $vm_snaplist = shift;
     my $output = "";
     my $state = 0;
-    $multiline = "<br>";
+
     foreach my $vm_snap (@{$vm_snaplist})
             {
             if ($vm_snap->{childSnapshotList})
@@ -159,7 +158,6 @@ sub check_snapshot_count
     my $recursion = shift || 0;
     my $output = "";
     my $state = 0;
-    $multiline = "<br>";
 
     foreach my $vm_snap (@{$vm_snaplist})
             {
@@ -203,6 +201,6 @@ sub final_state
        return $state2;
        }
     }
-# A module always must end with a returncode of 1. So placing 1 at the end of a module
+# A module always must end with a return code of 1. So placing 1 at the end of a module
 # is a common method to ensure this.
 1;

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -118,7 +118,7 @@ sub dc_snapshot_info
        }
     else
        {
-       if ($listall)
+       if ($listall && $output ne "")
           {
           $output = "No VMs with " . $output_subselect_text . " snapshots found. VMs:" . $multiline . $output;
           }
@@ -136,6 +136,7 @@ sub check_snapshot_age
     {
     my $vm_name = shift;
     my $vm_snaplist = shift;
+    my $recursion = shift || 0;
     my $output = "";
     my $state = 0;
 
@@ -143,7 +144,7 @@ sub check_snapshot_age
             {
             if ($vm_snap->{childSnapshotList})
                {
-               my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
+               my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList}, 1);
                if ($cstate || $listall)
                   {
                   $output .= $coutput . $multiline;
@@ -156,6 +157,10 @@ sub check_snapshot_age
             my $tstate = check_against_threshold($days_snap);
             if ($tstate || $listall)
                {
+              if ($recursion == 1 && $output ne "")
+                 {
+                 $output .= $multiline;
+                 }
                $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
                 $vm_snap->{name}, $vm_name, $days_snap;
                $state = final_state($state, $tstate);

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -28,6 +28,13 @@ sub dc_snapshot_info
 
     foreach $vm (@$vm_views)
             {
+           if (defined($vm_tools_poweredon_only))
+              {
+              if ($vm->{'runtime.powerState'}->val ne "poweredOn")
+                 {
+                 next;
+                 }
+              }
             my $vm_snapinfo = $vm->{snapshot};
             next unless defined $vm_snapinfo;
             # change get_property to {} to avoid infinite loop

--- a/modules/dc_snapshot_info.pm
+++ b/modules/dc_snapshot_info.pm
@@ -85,7 +85,7 @@ sub dc_snapshot_info
                {
                if ($listall)
                   {
-                  $output = $output . "$snapoutput" . $multiline;
+                  $output .= "$snapoutput" . $multiline;
                   }
                }
             }
@@ -100,7 +100,6 @@ sub dc_snapshot_info
     if ($count)
        {
        $output = "VMs with snapshots:" . $multiline . $output;
-       #$state = 1;
        }
     else
        {
@@ -132,7 +131,7 @@ sub check_snapshot_age
                my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
                if ($cstate)
                   {
-                  $output = $output . $multiline . $coutput;
+                  $output .= $coutput . $multiline;
                   $state = final_state($state, $cstate);
                   }
                }
@@ -142,8 +141,8 @@ sub check_snapshot_age
             my $tstate = check_against_threshold($days_snap);
             if ($tstate)
                {
-               $output = $output . $multiline . sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
-                $vm_snap->{name}, $vm_name, $days_snap;
+               $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
+                $vm_snap->{name}, $vm_name, $days_snap . $multiline;
                $state = final_state($state, $tstate);
                }
             }
@@ -170,8 +169,8 @@ sub check_snapshot_count
             if ($recursion == 0)
                {
                my $tstate = check_against_threshold($vm_snapcount->{$vm_name});
-               $output = $output . $multiline . sprintf "VM '%s' has %d snapshots",
-                   $vm_name, $vm_snapcount->{$vm_name};
+               $output .= sprintf "VM '%s' has %d snapshots",
+                   $vm_name, $vm_snapcount->{$vm_name} . $multiline;
                $state = final_state($state, $tstate);
                return ($state, $output);
                }
@@ -180,7 +179,7 @@ sub check_snapshot_count
 sub final_state
     {
     my ($state1, $state2) = @_;
-    my $final_state = 0;
+
     if ($state1)
        {
        if ($state2 == 2)

--- a/modules/help.pm
+++ b/modules/help.pm
@@ -324,6 +324,29 @@ sub print_help
        print "-S, --select=soap                   simple check to verify a successfull connection\n";
        print "                                    to VMWare SOAP API.\n";
        print "\n";
+       print "Snapshots\n";
+       print "-------------\n";
+       print "-S, --select=snapshots              List vm's wich have snapshots older or bigger than a certain threshold\n";
+       print "-w, --warning=<threshold>           Warning threshold.\n";
+       print "-c, --critical=<threshold>          Critical threshold.\n";
+       print "-B, --exclude=<black_list>          Blacklist VMs.\n";
+       print "-W, --include=<white_list>          Whitelist VMs.\n";
+       print "\n";
+       print "                                    Use blacklist OR(!) whitelist. Using both in one statement\n";
+       print "                                    is not allowed.\n";
+       print "\n";
+       print "    --isregexp                      Whether to treat blacklist and whitelist as regexp\n";
+       print "    --listall                       List all VMs with all snapshots.\n";
+       print "    --multiline                     Multiline output in overview. This mean technically that\n";
+       print "                                    a multiline output uses a HTML <br> for the GUI instead of\n";
+       print "                                    Be aware that your messing connections (email, SMS...) must use\n";
+       print "                                    a filter to file out the <br>. A sed oneliner like the following\n";
+       print "                                    will do the job: sed 's/<[^<>]*>//g'\n";
+       print "or with\n";
+       print "-s, --subselect=age                 Shows age of snapshots in days.\n";
+       print "or\n";
+       print "-s, --subselect=count               Counts the number of snapshots of VMs.\n";
+       print "\n";
        }
 
 #--- Host ----------------------
@@ -712,6 +735,29 @@ sub print_help
        print "-S, --select=soap                   Simple check to verify a successfull connection\n";
        print "                                    to VMWare SOAP API.\n";
        print "\n";
+       print "Snapshots\n";
+       print "-------------\n";
+       print "-S, --select=snapshots              List vm's wich have snapshots older or bigger than a certain threshold\n";
+       print "-w, --warning=<threshold>           Warning threshold.\n";
+       print "-c, --critical=<threshold>          Critical threshold.\n";
+       print "-B, --exclude=<black_list>          Blacklist VMs.\n";
+       print "-W, --include=<white_list>          Whitelist VMs.\n";
+       print "\n";
+       print "                                    Use blacklist OR(!) whitelist. Using both in one statement\n";
+       print "                                    is not allowed.\n";
+       print "\n";
+       print "    --isregexp                      Whether to treat blacklist and whitelist as regexp\n";
+       print "    --listall                       List all VMs with all snapshots.\n";
+       print "    --multiline                     Multiline output in overview. This mean technically that\n";
+       print "                                    a multiline output uses a HTML <br> for the GUI instead of\n";
+       print "                                    Be aware that your messing connections (email, SMS...) must use\n";
+       print "                                    a filter to file out the <br>. A sed oneliner like the following\n";
+       print "                                    will do the job: sed 's/<[^<>]*>//g'\n";
+       print "or with\n";
+       print "-s, --subselect=age                 Shows age of snapshots in days.\n";
+       print "or\n";
+       print "-s, --subselect=count               Counts the number of snapshots of VMs.\n";
+       print "\n";
        }
 
 
@@ -976,6 +1022,6 @@ sub print_help
        }
     }
 
-# A module always must end with a returncode of 1. So placing 1 at the end of a module 
+# A module always must end with a returncode of 1. So placing 1 at the end of a module
 # is a common method to ensure this.
 1;

--- a/modules/help.pm
+++ b/modules/help.pm
@@ -337,6 +337,7 @@ sub print_help
        print "\n";
        print "    --isregexp                      Whether to treat blacklist and whitelist as regexp\n";
        print "    --listall                       List all VMs with all snapshots.\n";
+       print "    --poweredonly                   List only VMs which are powered on.\n";
        print "    --multiline                     Multiline output in overview. This mean technically that\n";
        print "                                    a multiline output uses a HTML <br> for the GUI instead of\n";
        print "                                    Be aware that your messing connections (email, SMS...) must use\n";
@@ -748,6 +749,7 @@ sub print_help
        print "\n";
        print "    --isregexp                      Whether to treat blacklist and whitelist as regexp\n";
        print "    --listall                       List all VMs with all snapshots.\n";
+       print "    --poweredonly                   List only VMs which are powered on.\n";
        print "    --multiline                     Multiline output in overview. This mean technically that\n";
        print "                                    a multiline output uses a HTML <br> for the GUI instead of\n";
        print "                                    Be aware that your messing connections (email, SMS...) must use\n";

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -11,7 +11,7 @@ sub host_snapshot_info
     my $match;
     my $displayname;
     my $devices;
-   
+
     $host_view = Vim::find_entity_view(view_type => 'HostSystem', filter => $host, properties => ['name', 'runtime.inMaintenanceMode']);
     if (!defined($host_view))
        {
@@ -45,12 +45,12 @@ sub host_snapshot_info
             next unless defined $vm_snapinfo;
             # change get_property to {} to avoid infinite loop
             $istemplate = $vm->{'config.template'};
-            
+
             if ($istemplate && ($istemplate eq 'true'))
                {
                next;
                }
-            
+
             $match = 0;
             $displayname = $vm->name;
 
@@ -62,7 +62,7 @@ sub host_snapshot_info
                {
                $isregexp = 0;
                }
-               
+
             if (defined($blacklist))
                {
                if (isblacklisted(\$blacklist, $isregexp, $displayname))
@@ -92,7 +92,6 @@ sub host_snapshot_info
             if ($snapstate)
                {
                $state = final_state($state, $snapstate);
-               $multiline = "<br>";
                $count++;
                $output = "$snapoutput" . $multiline . $output;
                }
@@ -139,7 +138,7 @@ sub check_snapshot_age
     my $vm_snaplist = shift;
     my $output = "";
     my $state = 0;
-    $multiline = "<br>";
+
     foreach my $vm_snap (@{$vm_snaplist})
             {
             if ($vm_snap->{childSnapshotList})
@@ -173,7 +172,6 @@ sub check_snapshot_count
     my $recursion = shift || 0;
     my $output = "";
     my $state = 0;
-    $multiline = "<br>";
 
     foreach my $vm_snap (@{$vm_snaplist})
             {
@@ -217,6 +215,6 @@ sub final_state
        return $state2;
        }
     }
-# A module always must end with a returncode of 1. So placing 1 at the end of a module
+# A module always must end with a return code of 1. So placing 1 at the end of a module
 # is a common method to ensure this.
 1;

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -132,7 +132,7 @@ sub host_snapshot_info
        }
     else
        {
-       if ($listall)
+       if ($listall && $output ne "")
           {
           $output = "No VMs with " . $output_subselect_text . " snapshots found. VMs:" . $multiline . $output;
           }
@@ -150,6 +150,7 @@ sub check_snapshot_age
     {
     my $vm_name = shift;
     my $vm_snaplist = shift;
+    my $recursion = shift || 0;
     my $output = "";
     my $state = 0;
 
@@ -157,7 +158,7 @@ sub check_snapshot_age
             {
             if ($vm_snap->{childSnapshotList})
                {
-               my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
+               my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList}, 1);
                if ($cstate || $listall)
                   {
                   $output .= $coutput . $multiline;
@@ -170,6 +171,10 @@ sub check_snapshot_age
             my $tstate = check_against_threshold($days_snap);
             if ($tstate || $listall)
                {
+              if ($recursion == 1 && $output ne "")
+                 {
+                 $output .= $multiline;
+                 }
                $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
                 $vm_snap->{name}, $vm_name, $days_snap;
                $state = final_state($state, $tstate);

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -1,0 +1,222 @@
+sub host_snapshot_info
+    {
+    my ($host) = @_;
+    my $count = 0;
+    my $state;
+    my $output;
+    my $host_view;
+    my $vm_views;
+    my $vm;
+    my $istemplate;
+    my $match;
+    my $displayname;
+    my $devices;
+   
+    $host_view = Vim::find_entity_view(view_type => 'HostSystem', filter => $host, properties => ['name', 'runtime.inMaintenanceMode']);
+    if (!defined($host_view))
+       {
+       print "Host " . $$host{"name"} . " does not exist\n";
+       exit 2;
+       }
+
+    if (($host_view->get_property('runtime.inMaintenanceMode')) eq "true")
+       {
+       print "Notice: " . $host_view->name . " is in maintenance mode, check skipped\n";
+       exit 0;
+       }
+
+    $vm_views = Vim::find_entity_views(view_type => 'VirtualMachine', begin_entity => $host_view, properties => ['name', 'config.template', 'snapshot', 'runtime.powerState']);
+
+    if (!defined($vm_views))
+       {
+       print "Runtime error\n";
+       exit 2;
+       }
+    $output = '';
+
+    if (!defined($subselect))
+       {
+       $subselect = "age";
+       }
+
+    foreach $vm (@$vm_views)
+            {
+            my $vm_snapinfo = $vm->{snapshot};
+            next unless defined $vm_snapinfo;
+            # change get_property to {} to avoid infinite loop
+            $istemplate = $vm->{'config.template'};
+            
+            if ($istemplate && ($istemplate eq 'true'))
+               {
+               next;
+               }
+            
+            $match = 0;
+            $displayname = $vm->name;
+
+            if (defined($isregexp))
+               {
+               $isregexp = 1;
+               }
+            else
+               {
+               $isregexp = 0;
+               }
+               
+            if (defined($blacklist))
+               {
+               if (isblacklisted(\$blacklist, $isregexp, $displayname))
+                  {
+                  next;
+                  }
+               }
+            if (defined($whitelist))
+               {
+               if (isnotwhitelisted(\$whitelist, $isregexp, $displayname))
+                  {
+                  next;
+                  }
+               }
+            my $snapstate = 0;
+            my $snapoutput = "";
+            if ($subselect eq "age")
+               {
+               ($snapstate, $snapoutput) = check_snapshot_age( $vm->{name}, $vm_snapinfo->{rootSnapshotList} );
+               }
+               elsif ($subselect eq "count")
+               {
+               my %vm_snapshot_count;
+               ($snapstate, $snapoutput) = check_snapshot_count( $vm->{name},
+                   $vm_snapinfo->{rootSnapshotList}, \%vm_snapshot_count );
+               }
+            if ($snapstate)
+               {
+               $state = final_state($state, $snapstate);
+               $multiline = "<br>";
+               $count++;
+               $output = "$snapoutput" . $multiline . $output;
+               }
+               else
+               {
+               if ($listall)
+                  {
+                  $output = $output . "$snapoutput" . $multiline;
+                  }
+               }
+            }
+
+    #Cut the last multiline of $output. Second line is better than 2 time chop() like the original :-)
+    if ($output ne '')
+       {
+       $output  =~ s/<br>$//i;
+       $output  =~ s/\n$//i;
+       }
+
+    if ($count)
+       {
+       $output = "VMs with snapshots:" . $multiline . $output;
+       #$state = 1;
+       }
+    else
+       {
+       if ($listall)
+          {
+          $output = "No VMs with outdated/too many snapshots found. VMs." . $multiline . $output;
+          }
+       else
+          {
+          $output = "No VMs with outdated/too many snapshots found.";
+          }
+       $state = 0;
+       }
+
+    return ($state, $output);
+    }
+
+sub check_snapshot_age
+    {
+    my $vm_name = shift;
+    my $vm_snaplist = shift;
+    my $output = "";
+    my $state = 0;
+    $multiline = "<br>";
+    foreach my $vm_snap (@{$vm_snaplist})
+            {
+            if ($vm_snap->{childSnapshotList})
+               {
+               my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
+               if ($cstate)
+                  {
+                  $output = $output . $multiline . $coutput;
+                  $state = final_state($state, $cstate);
+                  }
+               }
+
+            my $epoch_snap = str2time( $vm_snap->{createTime} );
+            my $days_snap = ( ( time() - $epoch_snap ) / 86400 );
+            my $tstate = check_against_threshold($days_snap);
+            if ($tstate)
+               {
+               $output = $output . $multiline . sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
+                $vm_snap->{name}, $vm_name, $days_snap;
+               $state = final_state($state, $tstate);
+               }
+            }
+    return ($state, $output);
+    }
+
+sub check_snapshot_count
+    {
+    my $vm_name = shift;
+    my $vm_snaplist = shift;
+    my $vm_snapcount = shift;
+    my $recursion = shift || 0;
+    my $output = "";
+    my $state = 0;
+    $multiline = "<br>";
+
+    foreach my $vm_snap (@{$vm_snaplist})
+            {
+            if ($vm_snap->{childSnapshotList})
+               {
+               my ($cstate, $coutput) = check_snapshot_count($vm_name, $vm_snap->{childSnapshotList}, $vm_snapcount, 1);
+               }
+               $vm_snapcount->{$vm_name}++;
+            }
+            if ($recursion == 0)
+               {
+               my $tstate = check_against_threshold($vm_snapcount->{$vm_name});
+               $output = $output . $multiline . sprintf "VM '%s' has %d snapshots",
+                   $vm_name, $vm_snapcount->{$vm_name};
+               $state = final_state($state, $tstate);
+               return ($state, $output);
+               }
+    }
+
+sub final_state
+    {
+    my ($state1, $state2) = @_;
+    my $final_state = 0;
+    if ($state1)
+       {
+       if ($state2 == 2)
+          {
+          return $state2;
+          }
+          elsif ($state1 == 1 && $state2 == 3)
+          {
+          return $state1;
+          }
+          else
+          {
+          return $state1;
+          }
+       }
+       else
+       {
+       return $state2;
+       }
+    }
+# A module always must end with a returncode of 1. So placing 1 at the end of a module
+# is a common method to ensure this.
+1;

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -42,6 +42,13 @@ sub host_snapshot_info
 
     foreach $vm (@$vm_views)
             {
+           if (defined($vm_tools_poweredon_only))
+              {
+              if ($vm->{'runtime.powerState'}->val ne "poweredOn")
+                 {
+                 next;
+                 }
+              }
             my $vm_snapinfo = $vm->{snapshot};
             next unless defined $vm_snapinfo;
             # change get_property to {} to avoid infinite loop

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -4,6 +4,7 @@ sub host_snapshot_info
     my $count = 0;
     my $state;
     my $output;
+    my $output_subselect_text;
     my $host_view;
     my $vm_views;
     my $vm;
@@ -111,19 +112,26 @@ sub host_snapshot_info
        $output  =~ s/\n$//i;
        }
 
+    if ($subselect eq "age")
+       {
+       $output_subselect_text = "outdated";
+       } else {
+       $output_subselect_text = "too many";
+       }
+
     if ($count)
        {
-       $output = "VMs with snapshots:" . $multiline . $output;
+       $output = "VMs with " . $output_subselect_text . " snapshots:" . $multiline . $output;
        }
     else
        {
        if ($listall)
           {
-          $output = "No VMs with outdated/too many snapshots found. VMs:" . $multiline . $output;
+          $output = "No VMs with " . $output_subselect_text . " snapshots found. VMs:" . $multiline . $output;
           }
        else
           {
-          $output = "No VMs with outdated/too many snapshots found.";
+          $output = "No VMs with " . $output_subselect_text . " snapshots found.";
           }
        $state = 0;
        }
@@ -156,7 +164,7 @@ sub check_snapshot_age
             if ($tstate || $listall)
                {
                $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
-                $vm_snap->{name}, $vm_name, $days_snap . $multiline;
+                $vm_snap->{name}, $vm_name, $days_snap;
                $state = final_state($state, $tstate);
                }
             }
@@ -183,8 +191,8 @@ sub check_snapshot_count
             if ($recursion == 0)
                {
                my $tstate = check_against_threshold($vm_snapcount->{$vm_name});
-               $output .= sprintf "VM '%s' has %d snapshots",
-                   $vm_name, $vm_snapcount->{$vm_name} . $multiline;
+               $output .= sprintf "VM '%s' has %d snapshot%s",
+                   $vm_name, $vm_snapcount->{$vm_name}, ($vm_snapcount->{$vm_name} gt 1 ) ? "s" : "";
                $state = final_state($state, $tstate);
                return ($state, $output);
                }

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -99,7 +99,7 @@ sub host_snapshot_info
                {
                if ($listall)
                   {
-                  $output = $output . "$snapoutput" . $multiline;
+                  $output .= "$snapoutput" . $multiline;
                   }
                }
             }
@@ -114,7 +114,6 @@ sub host_snapshot_info
     if ($count)
        {
        $output = "VMs with snapshots:" . $multiline . $output;
-       #$state = 1;
        }
     else
        {
@@ -146,7 +145,7 @@ sub check_snapshot_age
                my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
                if ($cstate)
                   {
-                  $output = $output . $multiline . $coutput;
+                  $output .= $coutput . $multiline;
                   $state = final_state($state, $cstate);
                   }
                }
@@ -156,8 +155,8 @@ sub check_snapshot_age
             my $tstate = check_against_threshold($days_snap);
             if ($tstate)
                {
-               $output = $output . $multiline . sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
-                $vm_snap->{name}, $vm_name, $days_snap;
+               $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
+                $vm_snap->{name}, $vm_name, $days_snap . $multiline;
                $state = final_state($state, $tstate);
                }
             }
@@ -184,8 +183,8 @@ sub check_snapshot_count
             if ($recursion == 0)
                {
                my $tstate = check_against_threshold($vm_snapcount->{$vm_name});
-               $output = $output . $multiline . sprintf "VM '%s' has %d snapshots",
-                   $vm_name, $vm_snapcount->{$vm_name};
+               $output .= sprintf "VM '%s' has %d snapshots",
+                   $vm_name, $vm_snapcount->{$vm_name} . $multiline;
                $state = final_state($state, $tstate);
                return ($state, $output);
                }
@@ -194,7 +193,7 @@ sub check_snapshot_count
 sub final_state
     {
     my ($state1, $state2) = @_;
-    my $final_state = 0;
+
     if ($state1)
        {
        if ($state2 == 2)

--- a/modules/host_snapshot_info.pm
+++ b/modules/host_snapshot_info.pm
@@ -93,13 +93,13 @@ sub host_snapshot_info
                {
                $state = final_state($state, $snapstate);
                $count++;
-               $output = "$snapoutput" . $multiline . $output;
+               $output .= $snapoutput . $multiline;
                }
                else
                {
                if ($listall)
                   {
-                  $output .= "$snapoutput" . $multiline;
+                  $output .= $snapoutput . $multiline;
                   }
                }
             }
@@ -119,7 +119,7 @@ sub host_snapshot_info
        {
        if ($listall)
           {
-          $output = "No VMs with outdated/too many snapshots found. VMs." . $multiline . $output;
+          $output = "No VMs with outdated/too many snapshots found. VMs:" . $multiline . $output;
           }
        else
           {
@@ -143,7 +143,7 @@ sub check_snapshot_age
             if ($vm_snap->{childSnapshotList})
                {
                my ($cstate, $coutput) = check_snapshot_age($vm_name, $vm_snap->{childSnapshotList});
-               if ($cstate)
+               if ($cstate || $listall)
                   {
                   $output .= $coutput . $multiline;
                   $state = final_state($state, $cstate);
@@ -153,7 +153,7 @@ sub check_snapshot_age
             my $epoch_snap = str2time( $vm_snap->{createTime} );
             my $days_snap = ( ( time() - $epoch_snap ) / 86400 );
             my $tstate = check_against_threshold($days_snap);
-            if ($tstate)
+            if ($tstate || $listall)
                {
                $output .= sprintf "Snapshot \"%s\" (VM: '%s') is %0.1f days old",
                 $vm_snap->{name}, $vm_name, $days_snap . $multiline;


### PR DESCRIPTION
Hi,

this PR contains all commits I did to fix and enhance the --select=snaphots commit from @lausser.

This is now being used in our production environment and works quite well so far.

The Description
```
Snapshots
-------------
-S, --select=snapshots              List vm's wich have snapshots older or bigger than a certain threshold
-w, --warning=<threshold>           Warning threshold.
-c, --critical=<threshold>          Critical threshold.
-B, --exclude=<black_list>          Blacklist VMs.
-W, --include=<white_list>          Whitelist VMs.

                                    Use blacklist OR(!) whitelist. Using both in one statement
                                    is not allowed.

    --isregexp                      Whether to treat blacklist and whitelist as regexp
    --listall                       List all VMs with all snapshots.
    --poweredonly                   List only VMs which are powered on.
    --multiline                     Multiline output in overview. This mean technically that
                                    a multiline output uses a HTML <br> for the GUI instead of
                                    Be aware that your messing connections (email, SMS...) must use
                                    a filter to file out the <br>. A sed oneliner like the following
                                    will do the job: sed 's/<[^<>]*>//g'
or with
-s, --subselect=age                 Shows age of snapshots in days.
or
-s, --subselect=count               Counts the number of snapshots of VMs.
```

I've fixed a few problems with multiline output and added an option to only report snapshots of runnign VMs.