### PR TITLE
documented/renamed now option unplugged_nics_state

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -1358,15 +1358,15 @@
 #     - Replaced "elsif" by "else if" alos for clean indention and ....
 #     - New option --no_vm_tools_ok. It maybe for some reasons that you
 #       have virtual machines without VMware tools. This should not cause an alarm.
-#   - New option  --unconnected_nics. Sets status for unconnected nics. This option
-#     replaces hardcoded set to critical by Ricardo Burhenne
+#   - New option --unplugged_nics_state. Sets status for unplugged nics. This option
+#     replaces hardcoded set to critical by Ricardo Bartels
 #
 #     Possible values are:
 #     OK or ok
 #     CRITICAL or critical or CRIT or crit
 #     WARNING or warning or WARN or warn
 #
-#     Default is CRITICAL. Values are case insensitve.
+#     Default is WARNING. Values are case insensitve.
 #
 
 
@@ -1448,13 +1448,13 @@ my  $cluster;                                  # Name of the monitored cluster
 our $datacenter;                               # Name of the vCenter server
 our $vmname;                                   # Name of the virtual machine
 
-my  $unplugged_nics;                           # Which state should be deliverd in state of unconnected nics?
+my  $unplugged_nics_state;                     # Which state should be deliverd in state of unconnected nics?
 
                                                # Possible values are
                                                # OK or ok
                                                # CRITICAL or critical or CRIT or crit
                                                # WARNING or warning or WARN or warn
-my  $unplugged_nics_def="warning";             # Default status for unconnected nics?
+my  $unplugged_nics_state_def="warning";       # Default status for unconnected nics?
 
 my  $maintenance_mode_state;                   # Status in case ESX host is in maintenance mode
 
@@ -1623,7 +1623,7 @@ GetOptions
                                          "hidekey"                  => \$hidekey,
                                          "spaceleft"                => \$spaceleft,
                                          "maintenance_mode_state=s" => \$maintenance_mode_state,
-                                         "unplugged_nics=s"         => \$unplugged_nics,
+                                         "unplugged_nics_state=s"   => \$unplugged_nics_state,
          "V"   => \$version,             "version"                  => \$version,
          "d|debug" => \$DEBUG,
 );
@@ -1719,27 +1719,27 @@ else
    }
    
 # Set state for unconnected nics
-if (!(defined($unplugged_nics)))
+if (!(defined($unplugged_nics_state)))
    {
-   $unplugged_nics=$unplugged_nics_def;
+   $unplugged_nics_state=$unplugged_nics_state_def;
    }
 
 # We are using regex instead of a simple compare to be fault tolerant
-if ($unplugged_nics =~ m/^ok.*$/i)
+if ($unplugged_nics_state =~ m/^ok.*$/i)
    {
-   $unplugged_nics = 0;
+   $unplugged_nics_state = 0;
    }
 else
    {
-   if ($unplugged_nics =~ m/^wa.*$/i)
+   if ($unplugged_nics_state =~ m/^wa.*$/i)
       {
-      $unplugged_nics = 1;
+      $unplugged_nics_state = 1;
       }
    else
       {
-      if ($unplugged_nics =~ m/^cr.*$/i)
+      if ($unplugged_nics_state =~ m/^cr.*$/i)
          {
-         $unplugged_nics = 2;
+         $unplugged_nics_state = 2;
          }
       else
          {
@@ -2255,7 +2255,7 @@ sub main_select
           {
           require host_net_info;
           import host_net_info;
-          ($result, $output) = host_net_info($esx_server, $maintenance_mode_state, $unplugged_nics);
+          ($result, $output) = host_net_info($esx_server, $maintenance_mode_state, $unplugged_nics_state);
           return($result, $output);
           }
        if ($select eq "io")

--- a/command_reference
+++ b/command_reference
@@ -25,7 +25,7 @@ General options:
                                      WARNING or warning or WARN or warn
 
                                      Default is UNKNOWN because you do not know the real state.
-                                     Values are case insensitve.
+                                     Values are case insensitive.
 
     --ignore_warning                 Sometimes 2 (warning) is returned from a component.
                                      But the check itself is ok (from an operator view).
@@ -380,6 +380,15 @@ or
 -s, --subselect=nic                 Check all active NICs.
 -B, --exclude=<black_list>          Blacklist NICs.
     --isregexp                      Whether to treat blacklist as regexp
+
+    --unplugged_nics_state          Sets status for unplugged nics
+
+                                    Possible values are:
+                                    OK or ok
+                                    CRITICAL or critical or CRIT or crit
+                                    WARNING or warning or WARN or warn
+
+                                    Default is WARNING. Values are case insensitive.
 
 Volumes:
 --------

--- a/modules/help.pm
+++ b/modules/help.pm
@@ -104,7 +104,7 @@ sub print_help
        print "                                     WARNING or warning or WARN or warn\n";
        print "\n";
        print "                                     Default is UNKNOWN because you do not know the real state.\n";
-       print "                                     Values are case insensitve.\n";
+       print "                                     Values are case insensitive.\n";
        print "\n";
        print "    --ignore_warning                 Sometimes 2 (warning) is returned from a component.\n";
        print "                                     But the check itself is ok (from an operator view).\n";
@@ -471,6 +471,15 @@ sub print_help
        print "-s, --subselect=nic                 Check all active NICs.\n";
        print "-B, --exclude=<black_list>          Blacklist NICs.\n";
        print "    --isregexp                      Whether to treat blacklist as regexp\n";
+       print "\n";
+       print "    --unplugged_nics_state          Sets status for unplugged nics\n";
+       print "\n";
+       print "                                    Possible values are:\n";
+       print "                                    OK or ok\n";
+       print "                                    CRITICAL or critical or CRIT or crit\n";
+       print "                                    WARNING or warning or WARN or warn\n";
+       print "\n";
+       print "                                    Default is WARNING. Values are case insensitive.\n";
        print "\n";
        print "Volumes:\n";
        print "--------\n";

--- a/modules/host_net_info.pm
+++ b/modules/host_net_info.pm
@@ -3,7 +3,7 @@
 
 sub host_net_info
     {
-    my ($host, $maintenance_mode_state, $unplugged_nics) = @_;
+    my ($host, $maintenance_mode_state, $unplugged_nics_state) = @_;
     my $state = 0;
     my $value;
     my $output;
@@ -220,16 +220,16 @@ sub host_net_info
                                         {
                                         $output_nic = $output_nic . ", ";
                                         }
-                                     if ($unplugged_nics == 0)
+                                     if ($unplugged_nics_state == 0)
                                         {
                                         $output_nic = $output_nic . $multiline . $NIC{$nic_key}->device . " is unplugged but state is marked as ok.";
-                                        $state = $unplugged_nics;
+                                        $state = $unplugged_nics_state;
                                         $OKCount++;
                                         }
                                      else
                                         {
                                         $output_nic = $output_nic . $multiline . $NIC{$nic_key}->device . " is unplugged";
-                                        $state = $unplugged_nics;
+                                        $state = $unplugged_nics_state;
                                         $BadCount++;
                                         }
                                      }


### PR DESCRIPTION
* more consistant to maintenance_mode_state
* added description in help.pm/command_reference
* default return value is WARNING (not CRITICAL as in old description)