### PR TITLE
fix option maintenance_mode_state, now passed on to all host modules

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -2241,14 +2241,14 @@ sub main_select
           {
           require host_cpu_info;
           import host_cpu_info;
-          ($result, $output) = host_cpu_info($esx_server);
+          ($result, $output) = host_cpu_info($esx_server, $maintenance_mode_state);
           return($result, $output);
           }
        if ($select eq "mem")
           {
           require host_mem_info;
           import host_mem_info;
-          ($result, $output) = host_mem_info($esx_server);
+          ($result, $output) = host_mem_info($esx_server, $maintenance_mode_state);
           return($result, $output);
           }
        if ($select eq "net")
@@ -2262,7 +2262,7 @@ sub main_select
           {
           require host_disk_io_info;
           import host_disk_io_info;
-          ($result, $output) = host_disk_io_info($esx_server);
+          ($result, $output) = host_disk_io_info($esx_server, $maintenance_mode_state);
           return($result, $output);
           }
        if ($select eq "volumes")
@@ -2298,7 +2298,7 @@ sub main_select
           {
           require host_uptime_info;
           import host_uptime_info;
-          ($result, $output) = host_uptime_info($esx_server);
+          ($result, $output) = host_uptime_info($esx_server, $maintenance_mode_state);
           return($result, $output);
           }
        if ($select eq "hostmedia")

--- a/modules/host_cpu_info.pm
+++ b/modules/host_cpu_info.pm
@@ -1,6 +1,6 @@
 sub host_cpu_info
     {
-    my ($host) = @_;
+    my ($host, $maintenance_mode_state) = @_;
     my $state = 0;
     my $output;
     my $host_view;
@@ -14,7 +14,7 @@ sub host_cpu_info
                                  # 0 -> existing subselect
                                  # 1 -> non existing subselect
 
-    $values = return_host_performance_values($host,'cpu', ('wait.summation:*','ready.summation:*', 'usage.average'));
+    $values = return_host_performance_values($host, $maintenance_mode_state, 'cpu', ('wait.summation:*','ready.summation:*', 'usage.average'));
         
     if (defined($values))
        {
@@ -35,7 +35,7 @@ sub host_cpu_info
 
        if ($perf_val_error == 1)
           {
-          $values = return_host_performance_values($host,'cpu', ('wait.summation:*'));
+          $values = return_host_performance_values($host, $maintenance_mode_state, 'cpu', ('wait.summation:*'));
           }
 
        if (defined($values))
@@ -66,7 +66,7 @@ sub host_cpu_info
 
        if ($perf_val_error == 1)
           {
-          $values = return_host_performance_values($host,'cpu', ('ready.summation:*'));
+          $values = return_host_performance_values($host, $maintenance_mode_state, 'cpu', ('ready.summation:*'));
           }
 
        if (defined($values))
@@ -114,7 +114,7 @@ sub host_cpu_info
 
        if ($perf_val_error == 1)
           {
-          $values = return_host_performance_values($host,'cpu', ('usage.average'));
+          $values = return_host_performance_values($host, $maintenance_mode_state, 'cpu', ('usage.average'));
           }
 
        if (defined($values))

--- a/modules/host_disk_io_info.pm
+++ b/modules/host_disk_io_info.pm
@@ -1,6 +1,6 @@
 sub host_disk_io_info
     {
-    my ($host) = @_;
+    my ($host, $maintenance_mode_state) = @_;
     my $value;
     my $state = 0;
     my $output;
@@ -11,7 +11,7 @@ sub host_disk_io_info
                                  # 0 -> existing subselect
                                  # 1 -> non existing subselect
 
-    $values = return_host_performance_values($host, 'disk', ('commandsAborted.summation:*', 'busResets.summation:*', 'read.average:*', 'totalReadLatency.average:*', 'write.average:*', 'totalWriteLatency.average:*', 'usage.average:*', 'kernelLatency.average:*', 'deviceLatency.average:*', 'queueLatency.average:*', 'totalLatency.average:*'));
+    $values = return_host_performance_values($host, $maintenance_mode_state, 'disk', ('commandsAborted.summation:*', 'busResets.summation:*', 'read.average:*', 'totalReadLatency.average:*', 'write.average:*', 'totalWriteLatency.average:*', 'usage.average:*', 'kernelLatency.average:*', 'deviceLatency.average:*', 'queueLatency.average:*', 'totalLatency.average:*'));
 
     if (!defined($subselect))
        {

--- a/modules/host_mem_info.pm
+++ b/modules/host_mem_info.pm
@@ -1,6 +1,6 @@
 sub host_mem_info
     {
-    my ($host) = @_;
+    my ($host, $maintenance_mode_state) = @_;
     my $state = 0;
     my $output;
     my $value;
@@ -19,7 +19,7 @@ sub host_mem_info
                                  # 0 -> existing subselect
                                  # 1 -> non existing subselect
     
-    ($host_view, $values) = return_host_performance_values($host, 'mem', ( 'usage.average', 'consumed.average','swapused.average', 'overhead.average', 'vmmemctl.average'));
+    ($host_view, $values) = return_host_performance_values($host, $maintenance_mode_state, 'mem', ( 'usage.average', 'consumed.average','swapused.average', 'overhead.average', 'vmmemctl.average'));
         
     if (defined($values))
        {
@@ -46,7 +46,7 @@ sub host_mem_info
 
        if ($perf_val_error == 1)
           {
-          ($host_view, $values) = return_host_performance_values($host, 'mem', ( 'usage.average'));
+          ($host_view, $values) = return_host_performance_values($host, $maintenance_mode_state, 'mem', ( 'usage.average'));
           }
 
        if (defined($values))
@@ -79,7 +79,7 @@ sub host_mem_info
 
        if ($perf_val_error == 1)
           {
-          ($host_view, $values) = return_host_performance_values($host, 'mem', ( 'consumed.average'));
+          ($host_view, $values) = return_host_performance_values($host, $maintenance_mode_state, 'mem', ( 'consumed.average'));
           }
 
        if (defined($values))
@@ -129,7 +129,7 @@ sub host_mem_info
 
        if ($perf_val_error == 1)
           {
-          ($host_view, $values) = return_host_performance_values($host, 'mem', ( 'swapused.average'));
+          ($host_view, $values) = return_host_performance_values($host, $maintenance_mode_state, 'mem', ( 'swapused.average'));
           }
 
        if (defined($values))
@@ -216,7 +216,7 @@ sub host_mem_info
 
        if ($perf_val_error == 1)
           {
-          ($host_view, $values) = return_host_performance_values($host, 'mem', ( 'overhead.average'));
+          ($host_view, $values) = return_host_performance_values($host, $maintenance_mode_state, 'mem', ( 'overhead.average'));
           }
 
        if (defined($values))
@@ -266,7 +266,7 @@ sub host_mem_info
 
        if ($perf_val_error == 1)
           {
-          ($host_view, $values) = return_host_performance_values($host, 'mem', ( 'vmmemctl.average'));
+          ($host_view, $values) = return_host_performance_values($host, $maintenance_mode_state, 'mem', ( 'vmmemctl.average'));
           }
 
        if (defined($values))

--- a/modules/host_net_info.pm
+++ b/modules/host_net_info.pm
@@ -40,7 +40,7 @@ sub host_net_info
           }
        }
 
-    $values = return_host_performance_values($host, 'net', ('usage.average', 'received.average', 'transmitted.average'));
+    $values = return_host_performance_values($host, $maintenance_mode_state, 'net', ('usage.average', 'received.average', 'transmitted.average'));
 
 
     if (($subselect eq "usage") || ($subselect eq "all"))

--- a/modules/host_uptime_info.pm
+++ b/modules/host_uptime_info.pm
@@ -1,11 +1,11 @@
 sub host_uptime_info
    {
-   my ($host) = @_;
+   my ($host, $maintenance_mode_state) = @_;
    my $state = 2;
    my $output = 'HOST UPTIME Unknown error';
    my $value;
 
-   $values = return_host_performance_values($host, 'sys', ('uptime.latest'));
+   $values = return_host_performance_values($host, $maintenance_mode_state, 'sys', ('uptime.latest'));
 
    if (defined($values))
       {

--- a/modules/process_perfdata.pm
+++ b/modules/process_perfdata.pm
@@ -102,10 +102,15 @@ sub return_host_performance_values
     {
     my $values;
     my $host_name = shift(@_);
+    my $maintenance_mode_state = shift(@_);
     my $host_view;
 
     $host_view = Vim::find_entity_views(view_type => 'HostSystem', filter => $host_name, properties => (['name', 'runtime.inMaintenanceMode']) ); # Added properties named argument.
 
+    if (!defined($maintenance_mode_state))
+       {
+       $maintenance_mode_state = 0;
+       }
     if (!defined($host_view))
        {
        print "Runtime error\n";
@@ -121,7 +126,7 @@ sub return_host_performance_values
     if (($$host_view[0]->get_property('runtime.inMaintenanceMode')) eq "true")
        {
        print "Notice: " . $$host_view[0]->name . " is in maintenance mode, check skipped\n";
-       exit 0;
+       exit $maintenance_mode_state;
        }
 
     $values = generic_performance_values($host_view, @_);


### PR DESCRIPTION
Command option "--maintenance_mode_state" wasn't passed on to return_host_performance_values.

Previous behaviour would always return OK in maintenance mode and defeating the purpose of this option.