### PR TITLE
host_runtime_info: Ignore unknown states as this is expected behavior

### DIFF
--- a/modules/host_disk_io_info.pm
+++ b/modules/host_disk_io_info.pm
@@ -1,6 +1,6 @@
 sub host_disk_io_info
     {
-    my ($host) = @_;
+    my ($host, $maintenance_mode_state) = @_;
     my $value;
     my $state = 0;
     my $output;
@@ -11,7 +11,7 @@ sub host_disk_io_info
                                  # 0 -> existing subselect
                                  # 1 -> non existing subselect
 
-    $values = return_host_performance_values($host, 'disk', ('commandsAborted.summation:*', 'busResets.summation:*', 'read.average:*', 'totalReadLatency.average:*', 'write.average:*', 'totalWriteLatency.average:*', 'usage.average:*', 'kernelLatency.average:*', 'deviceLatency.average:*', 'queueLatency.average:*', 'totalLatency.average:*'));
+    $values = return_host_performance_values($host, $maintenance_mode_state, 'disk', ('commandsAborted.summation:*', 'busResets.summation:*', 'read.average:*', 'totalReadLatency.average:*', 'write.average:*', 'totalWriteLatency.average:*', 'usage.average:*', 'kernelLatency.average:*', 'deviceLatency.average:*', 'queueLatency.average:*', 'totalLatency.average:*'));
 
     if (!defined($subselect))
        {

--- a/modules/host_runtime_info.pm
+++ b/modules/host_runtime_info.pm
@@ -308,7 +308,13 @@ sub host_runtime_info
                                    };
                         push(@{$components->{$actual_state}{Storage}}, $itemref);
                         
-                        if ($actual_state != 0)
+                        if ($actual_state == 3)
+                           {
+                              # Ignore unknown sensors
+                              # https://kb.vmware.com/s/article/57171
+                              next;
+                           }
+                        elsif ($actual_state != 0)
                            {
                            $state = check_state($state, $actual_state);
                            $AlertCount++;
@@ -357,7 +363,13 @@ sub host_runtime_info
                                 };
                      push(@{$components->{$actual_state}{Memory}}, $itemref);
                      
-                     if ($actual_state != 0)
+                     if ($actual_state == 3)
+                        {
+                           # Ignore unknown sensors
+                           # https://kb.vmware.com/s/article/57171
+                           next;
+                        }
+                     elsif ($actual_state != 0)
                         {
                         $state = check_state($state, $actual_state);
                         $AlertCount++;
@@ -429,13 +441,14 @@ sub host_runtime_info
                                 };
                      push(@{$components->{$actual_state}{$_->sensorType}}, $itemref);
                      
-                     if ($actual_state != 0)
+                     if ($actual_state == 3)
                         {
-                        if (($actual_state == 3) && (!defined($ignoreunknown)))
-                           {
-                           # Trouble with the unknown status with sensors should better be a warning than unknown
-                           $actual_state = 1;
-                           }
+                           # Ignore unknown sensors
+                           # https://kb.vmware.com/s/article/57171
+                           next;
+                        }
+                      elsif ($actual_state != 0)
+                        {
                         $state = check_state($state, $actual_state);
                         $AlertCount++;
                         }


### PR DESCRIPTION
VMWare says unknown sensors are fine, since they are just not reporting any status.
    
See https://kb.vmware.com/s/article/57171

Also fixes #152 which was caused during a merge conflict resolution.
