### PR TITLE
Change selection criteria for temperature sensors

### DIFF
--- a/modules/host_runtime_info.pm
+++ b/modules/host_runtime_info.pm
@@ -637,7 +637,7 @@ sub host_runtime_info
              {
              foreach (@$numericSensorInfo)
                      {
-                     if (lc($_->sensorType) ne 'temperature')
+                     if (lc($_->baseUnits) !~ m/^degrees.*/)
                         {
                         next;
                         }


### PR DESCRIPTION
ESXi reports temperature sensors as category "Other" instead of "Temperature" for some vendors, change selection critera from Category to BaseUnit starting with "Degrees"