### PR TITLE
check_against_threshold

### DIFF
--- a/check_vmware_esx.pl
+++ b/check_vmware_esx.pl
@@ -2430,7 +2430,7 @@ sub check_against_threshold
 
     if ((defined($warning)) && (defined($critical)))
        {
-       if ( $warning >= $critical )
+       if ( $warning > $critical )
           {
           if ( $check_result <= $warning)
              {


### PR DESCRIPTION
This also might be the culprit behind #164.

if warning == critical check_against_threshold went
into a branch where it is critical when the value is below
the threshold. So

    -w 50 -c 50

behaved differently to just

    -c 50

Now, both of these behave the same.