### PR TITLE
host-runtime: Fully ignore unknown states for hardware

### DIFF
--- a/modules/host_runtime_info.pm
+++ b/modules/host_runtime_info.pm
@@ -306,8 +306,7 @@ sub host_runtime_info
                                    name => $_->name,
                                    summary => $_->status->summary
                                    };
-                        push(@{$components->{$actual_state}{Storage}}, $itemref);
-                        
+
                         if ($actual_state == 3)
                            {
                               # Ignore unknown sensors
@@ -316,6 +315,9 @@ sub host_runtime_info
                            }
                         else
                            {
+                           # Only add state for component if it is not unknown
+                           push(@{$components->{$actual_state}{Storage}}, $itemref);
+
                            if ($actual_state != 0)
                               {
                               $state = check_state($state, $actual_state);


### PR DESCRIPTION
Following up to #153, where I changed the state behavior. This now fully
ignores unknown states. Before they where listed with other errors, and
that is quite unreadable (50 unknown, 2 error)

See kb.vmware.com/s/article/57171