### PR TITLE
Stop failing if system has no hardware sensors

### DIFF
--- a/modules/host_runtime_info.pm
+++ b/modules/host_runtime_info.pm
@@ -235,9 +235,11 @@ sub host_runtime_info
 
        if (defined($runtime->healthSystemRuntime))
           {
-          $cpuStatusInfo = $runtime->healthSystemRuntime->hardwareStatusInfo->cpuStatusInfo;
-          $storageStatusInfo = $runtime->healthSystemRuntime->hardwareStatusInfo->storageStatusInfo;
-          $memoryStatusInfo = $runtime->healthSystemRuntime->hardwareStatusInfo->memoryStatusInfo;
+          if (defined($runtime->healthSystemRuntime->hardwareStatusInfo)) {
+            $cpuStatusInfo = $runtime->healthSystemRuntime->hardwareStatusInfo->cpuStatusInfo;
+            $storageStatusInfo = $runtime->healthSystemRuntime->hardwareStatusInfo->storageStatusInfo;
+            $memoryStatusInfo = $runtime->healthSystemRuntime->hardwareStatusInfo->memoryStatusInfo;
+          }
           $numericSensorInfo = $runtime->healthSystemRuntime->systemHealthInfo->numericSensorInfo;
 
           if (defined($cpuStatusInfo))


### PR DESCRIPTION
Script will fail with "cant call method"  if there are no sensors present on the system.
Checks if $runtime->healthSystemRuntime->hardwareStatusInfo is defined before trying to read its content.
Fixing #21