### PR TITLE
vm_cpu_info.pl: Not accept thresholds if no subselect

### DIFF
--- a/modules/vm_cpu_info.pm
+++ b/modules/vm_cpu_info.pm
@@ -26,6 +26,12 @@ sub vm_cpu_info
        # Therefore with all set no threshold check can be performed
        $subselect = "all";
        $true_sub_sel = 0;
+       if ($perf_thresholds ne ';')
+          {
+          print_help();
+          print "\nERROR! Thresholds only allowed wint subselects!\n\n";
+          exit 2;
+          }
        }
 
     if (($subselect eq "wait") || ($subselect eq "all"))

--- a/modules/vm_cpu_info.pm
+++ b/modules/vm_cpu_info.pm
@@ -29,7 +29,7 @@ sub vm_cpu_info
        if ($perf_thresholds ne ';')
           {
           print_help();
-          print "\nERROR! Thresholds only allowed wint subselects!\n\n";
+          print "\nERROR! Thresholds only allowed with subselects!\n\n";
           exit 2;
           }
        }


### PR DESCRIPTION
Calling:
`./check_vmware_esx.pl -H $HOSTNAME$ -u $ARG1$ -p $ARG2$ -S cpu -w $ARG3$ -c $ARG4$`

Won't check the thresholds and neither exits with error. 

Now added code copy/pasted from `vm_mem_info.pl` to check `$perf_thresholds` if `$subselect` is not defined, and throw error if needed.