### PR TITLE
host_storage_info.pm - Fix count of Multipaths when using Blacklist / Whitelist

### DIFF
--- a/modules/host_storage_info.pm
+++ b/modules/host_storage_info.pm
@@ -373,7 +373,6 @@ sub host_storage_info
                                 {
                                 if ($scsi_id ne $scsi_id_old)
                                    {
-                                   $mpath_cnt++;
                                    $ignored++;
                                    next;
                                    }
@@ -385,7 +384,6 @@ sub host_storage_info
                                 {
                                 if ($scsi_id ne $scsi_id_old)
                                    {
-                                   $mpath_cnt++;
                                    $ignored++;
                                    next;
                                    }


### PR DESCRIPTION
IHMO, it seems like when using Blacklist or Whitelist option, the variable $mpath_cnt is incremented, while for the same path its also incremented in line 412 anyway.